### PR TITLE
fix label pushed off-screen

### DIFF
--- a/src/components/label/index.js
+++ b/src/components/label/index.js
@@ -70,10 +70,10 @@ export default class Label extends PureComponent {
       return null;
     }
 
-    let color = disabled?
-      baseColor:
-      restricted?
-        errorColor:
+    let color = disabled ?
+      baseColor :
+      restricted ?
+        errorColor :
         focusAnimation.interpolate({
           inputRange: [-1, 0, 1],
           outputRange: [errorColor, baseColor, tintColor],
@@ -90,14 +90,25 @@ export default class Label extends PureComponent {
     y0 += activeFontSize;
     y0 += contentInset.label;
     y0 += fontSize * 0.25;
+    let animatedTextStyle = {
+  transform: [
+    {
+      translateX: labelAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [0, -(fontSize * 0.9)],
+      }),
+    },
+    {
+      scale: labelAnimation.interpolate({
+        inputRange: [0, 1],
+        outputRange: [1, activeFontSize / fontSize],
+      }),
+    },
+  ],
+};
 
     let containerStyle = {
-      transform: [{
-        scale: labelAnimation.interpolate({
-          inputRange: [0, 1],
-          outputRange: [1, activeFontSize / fontSize],
-        }),
-      }, {
+      transform: [ {
         translateY: labelAnimation.interpolate({
           inputRange: [0, 1],
           outputRange: [y0, y1],
@@ -112,7 +123,7 @@ export default class Label extends PureComponent {
 
     return (
       <Animated.View style={[styles.container, containerStyle]}>
-        <Animated.Text style={[styles.text, style, textStyle]} {...props}>
+        <Animated.Text style={[styles.text, style, textStyle, animatedTextStyle]} {...props}>
           {label}
         </Animated.Text>
       </Animated.View>

--- a/src/components/label/styles.js
+++ b/src/components/label/styles.js
@@ -1,13 +1,13 @@
 import { StyleSheet } from 'react-native';
 
 export default StyleSheet.create({
-  container: {
-    position: 'absolute',
-    top: 0,
-    left: '-100%',
-    width: '200%',
-    paddingLeft: '50%',
-  },
+container: {
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  width: '100%',
+  alignItems: 'flex-start',
+},
 
   text: {
     textAlign: 'left',


### PR DESCRIPTION
## What?
After upgrading react native version of the NDApp the text is now pushed out of the screen possible reason:
Older versions of React Native might have handled % values for positioning and padding in a more forgiving or different way. However, React Native's layout engine (Yoga) has become stricter and more consistent with web-like behavior in newer versions.

    left: '-100%' pushes the container fully off the screen to the left.

    Then width: '200%' makes the element twice the width of the screen.

    paddingLeft: '50%' is trying to shift the content back to center, but this approach is fragile and likely not behaving the same anymore.